### PR TITLE
chore: migrate deprecated mongodb node driver options

### DIFF
--- a/seedPrompts.js
+++ b/seedPrompts.js
@@ -1,6 +1,6 @@
 async function seedPrompts() {
     try {
-        await mongoose.connect(config.mongodbUri, { useNewUrlParser: true, useUnifiedTopology: true });
+        await mongoose.connect(config.mongodbUri, {  });
         console.log('Connected to MongoDB');
 
         for (let prompt of prompts) {

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,7 @@ const setupSocketHandlers = require('./utils/socketHandlers');
 const server = http.createServer(app);
 const io = socketIo(server);
 
-mongoose.connect(config.mongodbUri + '/drawing_game', { useNewUrlParser: true, useUnifiedTopology: true })
+mongoose.connect(config.mongodbUri + '/drawing_game', {  })
   .then(() => console.log('Connected to MongoDB'))
   .catch(err => console.error('MongoDB connection error:', err));
 


### PR DESCRIPTION
## Summary
- remove deprecated mongodb node driver options:
  - useNewUrlParser / usenewurlparser
  - useUnifiedTopology / useunifiedtopology
  - reconnectTries
  - reconnectInterval
- rename poolSize / poolsize to maxPoolSize where applicable

## Validation
- syntax checks passed for modified source files
- lint/build/test verification was executed where scripts were available
- remaining failures are pre-existing test/env issues unrelated to this migration

## Notes
- this PR is part of a repo-wide migration sweep to align examples and apps with current mongodb driver behavior
